### PR TITLE
ESP8266 compatibility

### DIFF
--- a/RF433any.cpp
+++ b/RF433any.cpp
@@ -1143,6 +1143,9 @@ void Track::treset() {
     rawcode.nb_sections = 0;
 }
 
+#if defined(ESP8266)
+IRAM_ATTR
+#endif
 void Track::ih_handle_interrupt() {
     static unsigned long last_t = 0;
     const unsigned long t = micros();
@@ -1571,6 +1574,9 @@ bool Track::do_events() {
     return false;
 }
 
+#if defined(ESP8266)
+IRAM_ATTR
+#endif
 void Track::ih_handle_interrupt_wait_free() {
     static unsigned long last_t = 0;
 


### PR DESCRIPTION
Adding the `IRAM_ATTR` flag on the interrupt handlers when compiling for ESP8266.

See https://arduino-esp8266.readthedocs.io/en/latest/reference.html#interrupts

Tested, works fine.